### PR TITLE
Fix CI to validate each template individually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           version: 1.11.0
 
-      - name: Initialize Packer
-        run: packer init templates/
-
-      - name: Check formatting
-        run: packer fmt -check templates/
-
       - name: Validate templates
-        run: packer validate templates/
+        run: |
+          for template in templates/*.pkr.hcl; do
+            echo "=== Validating $template ==="
+            packer init "$template"
+            packer fmt -check "$template"
+            packer validate "$template"
+          done


### PR DESCRIPTION
## Problem

CI fails with:
```
Error: Duplicate variable
Duplicate output_name variable definition found.
```

## Root Cause

Packer treats a directory as a single merged configuration. Since each template defines its own `output_name` and `ssh_private_key_file` variables, `packer init templates/` sees duplicates.

## Fix

Validate each template individually in a loop, matching how `build.sh` works locally.

## Testing

CI should pass after this change.