### PR TITLE
fix: Support `latest` target in copy-images workflow (.github#30)

### DIFF
--- a/.github/workflows/copy-images.yml
+++ b/.github/workflows/copy-images.yml
@@ -25,8 +25,9 @@ jobs:
             echo "Error: Invalid source release format. Expected vX.Y (e.g., v0.17)"
             exit 1
           fi
-          if [[ ! "${{ inputs.target_release }}" =~ ^v[0-9]+\.[0-9]+ ]]; then
-            echo "Error: Invalid target release format. Expected vX.Y (e.g., v0.18)"
+          # Target can be 'latest' or vX.Y format
+          if [[ "${{ inputs.target_release }}" != "latest" ]] && [[ ! "${{ inputs.target_release }}" =~ ^v[0-9]+\.[0-9]+ ]]; then
+            echo "Error: Invalid target release format. Expected 'latest' or vX.Y (e.g., v0.18)"
             exit 1
           fi
 
@@ -49,13 +50,30 @@ jobs:
           fi
           echo "Found $ASSET_COUNT image(s) in source release"
 
-      - name: Check target release exists
+      - name: Ensure target release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view "${{ inputs.target_release }}" --repo ${{ github.repository }} >/dev/null 2>&1; then
-            echo "Error: Target release ${{ inputs.target_release }} not found"
-            echo "Create the release first with: gh release create ${{ inputs.target_release }}"
+          TARGET="${{ inputs.target_release }}"
+
+          if gh release view "$TARGET" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "Target release $TARGET exists"
+          elif [[ "$TARGET" == "latest" ]]; then
+            # Create 'latest' release if it doesn't exist
+            echo "Creating 'latest' release..."
+            SOURCE_SHA=$(gh api repos/${{ github.repository }}/git/refs/tags/${{ inputs.source_release }} --jq '.object.sha' 2>/dev/null || echo "")
+            if [[ -z "$SOURCE_SHA" ]]; then
+              echo "Error: Could not get SHA for source release"
+              exit 1
+            fi
+            gh release create latest --repo ${{ github.repository }} \
+              --title "Latest Release" \
+              --notes "Points to latest stable images" \
+              --target "$SOURCE_SHA"
+            echo "Created 'latest' release"
+          else
+            echo "Error: Target release $TARGET not found"
+            echo "Create the release first with: gh release create $TARGET"
             exit 1
           fi
 
@@ -102,29 +120,44 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Updating 'latest' tag to point to ${{ inputs.target_release }}..."
+          TARGET="${{ inputs.target_release }}"
+          SOURCE="${{ inputs.source_release }}"
 
-          # Get the commit SHA for the target release tag
-          TARGET_SHA=$(gh api repos/${{ github.repository }}/git/refs/tags/${{ inputs.target_release }} --jq '.object.sha' 2>/dev/null || echo "")
+          # When target is 'latest', point tag to source release commit
+          # When target is versioned, point tag to target release commit
+          if [[ "$TARGET" == "latest" ]]; then
+            REF_TAG="$SOURCE"
+            echo "Updating 'latest' tag to point to $SOURCE (source release)..."
+          else
+            REF_TAG="$TARGET"
+            echo "Updating 'latest' tag to point to $TARGET..."
+          fi
+
+          # Get the commit SHA for the reference tag
+          TARGET_SHA=$(gh api repos/${{ github.repository }}/git/refs/tags/$REF_TAG --jq '.object.sha' 2>/dev/null || echo "")
 
           if [[ -z "$TARGET_SHA" ]]; then
-            echo "Warning: Could not get SHA for ${{ inputs.target_release }}, skipping latest tag update"
+            echo "Warning: Could not get SHA for $REF_TAG, skipping latest tag update"
             exit 0
           fi
 
+          echo "Reference SHA: $TARGET_SHA"
+
           # Check if latest tag exists
           if gh api repos/${{ github.repository }}/git/refs/tags/latest >/dev/null 2>&1; then
-            # Update existing tag
+            # Update existing tag (use -F for boolean type)
+            echo "Updating existing 'latest' tag..."
             gh api -X PATCH repos/${{ github.repository }}/git/refs/tags/latest \
               -f sha="$TARGET_SHA" \
-              -f force=true
+              -F force=true
             echo "Updated 'latest' tag to $TARGET_SHA"
           else
             # Create new tag
+            echo "Creating 'latest' tag..."
             gh api -X POST repos/${{ github.repository }}/git/refs \
               -f ref="refs/tags/latest" \
               -f sha="$TARGET_SHA"
             echo "Created 'latest' tag pointing to $TARGET_SHA"
           fi
 
-          echo "✓ 'latest' tag now points to ${{ inputs.target_release }}"
+          echo "✓ 'latest' tag now points to $REF_TAG ($TARGET_SHA)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - Fix redundant -pve suffix in versioned image names (#34)
   - `debian-13-pve` now produces `deb13.x-pve9.x.qcow2` instead of `deb13.x-pve9.x-pve.qcow2`
 
+- Fix copy-images workflow to support `latest` as target (.github#30)
+  - Relaxed validation to accept `latest` OR `vX.Y` format
+  - Auto-create `latest` release if it doesn't exist
+  - Fix `force` parameter type in tag update API call (use `-F` for boolean)
+
 - Fix cleanup script sourcing for per-template structure (#32)
   - Upload `cleanup-common.sh` to VM via file provisioner before sourcing
   - Scripts now source from `/tmp/cleanup-common.sh` on build VM


### PR DESCRIPTION
## Summary

Fixes the copy-images workflow to properly support `latest` as a target release.

## Changes

1. **Validation relaxed**: Accept `latest` OR `vX.Y` format for target release
2. **Auto-create latest release**: If `latest` doesn't exist, create it
3. **Fix force parameter**: Use `-F force=true` for boolean (was `-f force=true` which sends string)
4. **Improved logging**: Added SHA references and clearer debug output

## Test plan

- [ ] `gh workflow run copy-images.yml -f source_release=v0.21 -f target_release=latest` succeeds
- [ ] `gh workflow run copy-images.yml -f source_release=v0.21 -f target_release=v0.22` succeeds
- [ ] `latest` tag is updated correctly in both scenarios

## Related

Closes .github#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)